### PR TITLE
Expand script paths that vim shortens in scriptnames report

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -538,7 +538,7 @@ function! s:snr_prefix(sfile)
 
   for line in split(result, '\n')
     let _ = matchlist(line, '^\s*\(\d\+\):\s*\(.*\)$')
-    if a:sfile ==# _[2]
+    if a:sfile ==# expand(_[2])
       return printf("\<SNR>%d_", _[1])
     endif
   endfor


### PR DESCRIPTION
I'm not sure when in the console version of vim this started happening since I regularly use MacVim.

The output of scriptnames in the console version (7.3.237) has started to shorten the part of the path to the home directory as `~`. This small change allows it to work in all versions of vim that I use currently, gui and console.
