### PR TITLE
Fix dependency on 'ignorecase'

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -394,16 +394,16 @@ function! s:plugin.define_interface_key_mappings()  "{{{3
       elseif has_key(specs, '*pattern*')
         if spec_name =~# '^move-[npNP]$'
           let flags = ''
-          let flags .= (spec_name =~ '[pP]$' ? 'b' : '')
-          let flags .= (spec_name =~ '[NP]$' ? 'e' : '')
+          let flags .= (spec_name =~# '[pP]$' ? 'b' : '')
+          let flags .= (spec_name =~# '[NP]$' ? 'e' : '')
           let impl_fname = 'move'
         elseif spec_name ==# 'select'
           let flags = ''
           let impl_fname = 'select'
         elseif spec_name =~# '^select-[ai]$'
           let flags = ''
-          let flags .= (spec_name =~ 'a$' ? 'a' : '')
-          let flags .= (spec_name =~ 'i$' ? 'i' : '')
+          let flags .= (spec_name =~# 'a$' ? 'a' : '')
+          let flags .= (spec_name =~# 'i$' ? 'i' : '')
           let impl_fname = 'select_pair'
         else
           echoerr 'Unknown spec:' string(spec_name)


### PR DESCRIPTION
s:plugin.define_interface_key_mappings() defines key mappings incorrectly when 'ignorecase' is enabled. I wrote a patch to fix the problem.
