### PR TITLE
Fix error if Vim run under Windows with noshellslash.

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -538,7 +538,9 @@ function! s:snr_prefix(sfile)
 
   for line in split(result, '\n')
     let _ = matchlist(line, '^\s*\(\d\+\):\s*\(.*\)$')
-    if fnamemodify(a:sfile, ':p') ==# fnamemodify(_[2], ':p')
+    if fnamemodify(a:sfile, ':p') ==# ((exists('+shellslash') && empty(&shellslash))
+    \ ? fnamemodify(expand(_[2]), ':p')
+    \ : fnamemodify(_[2], ':p'))
       return printf("\<SNR>%d_", _[1])
     endif
   endfor


### PR DESCRIPTION
ごく一部のWindows環境で`s:snr_prefix()`が正常に動作せず、一部の textobj-user プラグインが動作しないのを修正します。
## 発生条件
- Windows で Vim 7.3.233 以降を使っている (kaoriya版もしくは独自ビルド)
- `set noshellslash`
- 利用するtextobj-user プラグイン が、 `’*sfile*' : 'expand('<sfile>:p')`している (textobj-user-comment など)
- Windows の msysgit に含まれる Git Bash を利用し、そこから該当するバージョンのVimを起動している
## 不具合内容

Vim 7.3.233 以降では、`:scriptnames`の＄HOMEを'~'に短縮する処理が追加されました。
Windows環境では殆どの場合において短縮処理が正常に働かないので、問題はなかったのですが、
[msysgit](http://code.google.com/p/msysgit/)のGit Bash上から(g)Vimを起動した場合のみ、
このパス短縮処理が正常に働いてしまいます。

該関数で、`expand('<sfile>:p')`した結果（これはvim-textobj-userプラグインの'_sfile_'プロパティで指定されています）と`:scriptnames`の結果を`fnamemodify(, ':p')`しますが、
このとき、`set shellslash`していない場合には、パス区切り文字が '/' と '\' で異なってしまい、正常に`<SNR>`を取得できなくなります。
