### PR TITLE
Avoid E706 errors when using textobj#user#define().

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -178,6 +178,8 @@ function! textobj#user#define(pat0, pat1, pat2, guideline)  "{{{2
         throw 'Unknown function name: ' . string(function_name)
       endif
     endfor
+
+    unlet _lhss   " to avoid E706.
   endfor
 endfunction
 


### PR DESCRIPTION
_lhss is sometimes a string, and sometimes a list.  Unlet it at the end
of the loop to avoid Vim's sticky type errors (E706).
