### PR TITLE
Ignore doc/tags as well (to allow use with pathogen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+doc/tags


### PR DESCRIPTION
Every run of pathogen creates `doc/tags` file to index help file.
