### PR TITLE
Ensure the matchlist is sufficiently long before accessing it.

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -636,7 +636,11 @@ function! s:snr_prefix(sfile)
 
   for line in split(result, '\n')
     let _ = matchlist(line, '^\s*\(\d\+\):\s*\(.*\)$')
-    if s:normalize_path(a:sfile) ==# s:normalize_path(_[2])
+
+    " _ could be an empty list if vim was run with the verbosity turned up high
+    " (such as -V20).  Check the list size before accessing it to ensure that
+    " enough elements are present.
+    if len(_) > 2 && s:normalize_path(a:sfile) ==# s:normalize_path(_[2])
       return printf("\<SNR>%d_", _[1])
     endif
   endfor


### PR DESCRIPTION
When running Vim in verbose mode, the `silent scriptnames` line in
`s:snr_prefix` will cause the result to contain a line such as the
following at the beginning of the result:
    ^@line 2:   silent scriptnames

This line does not match the pattern, so an empty list is returned.
However, the subsequent line attempts to access the empty list causing
an error.  Let's check the list before accessing the elements.
