### PR TITLE
Fix example mapping to match description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ define `il` to select the current line without indentation:
 call textobj#user#plugin('line', {
 \   '-': {
 \     'select-a-function': 'CurrentLineA',
-\     'select-a': 'aP',
+\     'select-a': 'al',
 \     'select-i-function': 'CurrentLineI',
-\     'select-i': 'iP',
+\     'select-i': 'il',
 \   },
 \ })
 


### PR DESCRIPTION
Readme says it's defining `il`, but then defines `iP`. Update to use
`il`. Same for aP -> aL.
