### PR TITLE
Restore cursor position in s:cancel_selection always

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -649,10 +649,9 @@ endfunction
 
 
 function! s:cancel_selection(previous_mode, orig_pos)
+  call cursor(a:orig_pos)
   if a:previous_mode ==# 'v'
     normal! gv
-  else  " if a:previous_mode ==# 'o'
-    call cursor(a:orig_pos)
   endif
 endfunction
 


### PR DESCRIPTION
I've noticed that `vif` (using
[vim-textobj-python](https://github.com/bps/vim-textobj-python.git))
would cause the window to scroll when the `normal! gv` was called.
Restoring the cursor position also for visual mode fixed this for me.

Apparently it breaks no test, but there should probably be one added for
this - in case it's not caused by some other plugin / config from me.
