### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+doc/tags


### PR DESCRIPTION
I did this so that people would be able to use git submodules to manage
this Vim plugin without the Vim generated doc/tags being seen as a
change.