### PR TITLE
Allow for not selecting in select

### DIFF
--- a/autoload/textobj/user.vim
+++ b/autoload/textobj/user.vim
@@ -49,7 +49,9 @@ function! textobj#user#select(pattern, flags, previous_mode)
   let pos = s:choose_better_pos(a:flags, ORIG_POS, pfh, pft, pbh, pbt)
 
   if pos isnot 0
-    call s:range_select(pos[0], pos[1], s:choose_wise(a:flags))
+    if a:flags !~# 'N'
+      call s:range_select(pos[0], pos[1], s:choose_wise(a:flags))
+    endif
     return pos
   else
     return s:cancel_selection(a:previous_mode, ORIG_POS)

--- a/doc/textobj-user.txt
+++ b/doc/textobj-user.txt
@@ -464,6 +464,7 @@ textobj#user#select({pattern}, {flags}, {prevous-mode})
 		"v"             select an object characterwise.  (default)
 		"V"             select an object linewise.
 		"\<C-v>"        select an object blockwise.
+		"N"             find the range but don't select.
 
 	For the detail of {previous-mode}, see |textobj#user#move()|.
 


### PR DESCRIPTION
This is a bit counter-intuitive maybe . . . since the function is called "select" it makes sense that it always selects. _However_ . . . in trying to fix vim-textobj-xmlattr to support jsx attributes, I was looking for the easiest way to re-use the existing regular expressions for current functionality, and then checking for jsx attributes after that. The easiest way to do this correctly is to use a function instead of a pattern and call `textobj#user#select` with the existing pattern, but that _only_ works correctly if I take out the call to `s:range_select`. So in essence, this pull request would just make that function reusable as an easy way to get start and end positions for any regex match.