### PR TITLE
Ignore generated doc tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+# Ignore generate doc tags
+/doc/tags


### PR DESCRIPTION
I use a git checkout to `~/.vim/bundle/textobj-user` and it always complains of untracked content because of the generated `doc/tags` file — this should fix it for everyone. Thanks for the useful plugin! 😄 